### PR TITLE
feat: schema builder + content editor microCMS overhaul

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -51,7 +51,7 @@
         "shadcn": "^3.8.4",
         "tailwindcss": "^4",
         "tw-animate-css": "^1.4.0",
-        "typescript": "^5"
+        "typescript": "5.9.3"
       }
     },
     "node_modules/@alloc/quick-lru": {

--- a/package.json
+++ b/package.json
@@ -55,6 +55,6 @@
     "shadcn": "^3.8.4",
     "tailwindcss": "^4",
     "tw-animate-css": "^1.4.0",
-    "typescript": "^5"
+    "typescript": "5.9.3"
   }
 }

--- a/src/app/(dashboard)/services/[serviceId]/apis/[apiId]/contents/[contentId]/editor-wrapper.tsx
+++ b/src/app/(dashboard)/services/[serviceId]/apis/[apiId]/contents/[contentId]/editor-wrapper.tsx
@@ -6,6 +6,7 @@ import { toast } from "sonner";
 import { ContentEditor } from "@/features/content-hub/manage-content/components/content-editor";
 import type { SchemaFieldDef } from "@/features/content-hub/manage-content/components/field-renderers";
 import { updateContent } from "@/features/content-hub/manage-content/action";
+import type { CustomField } from "@/features/content-hub/model";
 
 interface EditContentWrapperProps {
   serviceId: string;
@@ -14,6 +15,7 @@ interface EditContentWrapperProps {
   schemaFields: SchemaFieldDef[];
   initialData: Record<string, unknown>;
   status: string;
+  customFields?: CustomField[];
 }
 
 export function EditContentWrapper({
@@ -23,6 +25,7 @@ export function EditContentWrapper({
   schemaFields,
   initialData,
   status,
+  customFields,
 }: EditContentWrapperProps) {
   const router = useRouter();
 
@@ -59,6 +62,7 @@ export function EditContentWrapper({
       status={status}
       onSaveDraft={handleSaveDraft}
       onPublish={handlePublish}
+      customFields={customFields}
     />
   );
 }

--- a/src/app/(dashboard)/services/[serviceId]/apis/[apiId]/contents/[contentId]/page.tsx
+++ b/src/app/(dashboard)/services/[serviceId]/apis/[apiId]/contents/[contentId]/page.tsx
@@ -1,5 +1,6 @@
 import { notFound } from "next/navigation";
 import { getSchemaFields } from "@/features/content-hub/manage-schema/query";
+import { getCustomFields } from "@/features/content-hub/manage-custom-fields/query";
 import { getContentForEdit } from "@/features/content-hub/manage-content/query";
 import type { SchemaFieldDef } from "@/features/content-hub/manage-content/components/field-renderers";
 
@@ -12,9 +13,10 @@ export default async function EditContentPage({
 }) {
   const { serviceId, apiId, contentId } = await params;
 
-  const [fields, content] = await Promise.all([
+  const [fields, content, customFieldList] = await Promise.all([
     getSchemaFields(apiId),
     getContentForEdit(contentId),
+    getCustomFields(apiId),
   ]);
 
   if (!content) {
@@ -40,6 +42,7 @@ export default async function EditContentPage({
       schemaFields={schemaFields}
       initialData={content.editData}
       status={content.status}
+      customFields={customFieldList}
     />
   );
 }

--- a/src/app/(dashboard)/services/[serviceId]/apis/[apiId]/contents/new/editor-wrapper.tsx
+++ b/src/app/(dashboard)/services/[serviceId]/apis/[apiId]/contents/new/editor-wrapper.tsx
@@ -6,12 +6,14 @@ import { toast } from "sonner";
 import { ContentEditor } from "@/features/content-hub/manage-content/components/content-editor";
 import type { SchemaFieldDef } from "@/features/content-hub/manage-content/components/field-renderers";
 import { createContent } from "@/features/content-hub/manage-content/action";
+import type { CustomField } from "@/features/content-hub/model";
 
 interface ContentEditorWrapperProps {
   serviceId: string;
   apiId: string;
   schemaFields: SchemaFieldDef[];
   isNew: boolean;
+  customFields?: CustomField[];
 }
 
 export function ContentEditorWrapper({
@@ -19,6 +21,7 @@ export function ContentEditorWrapper({
   apiId,
   schemaFields,
   isNew,
+  customFields,
 }: ContentEditorWrapperProps) {
   const router = useRouter();
 
@@ -58,6 +61,7 @@ export function ContentEditorWrapper({
       isNew={isNew}
       onSaveDraft={handleSaveDraft}
       onPublish={handlePublish}
+      customFields={customFields}
     />
   );
 }

--- a/src/app/(dashboard)/services/[serviceId]/apis/[apiId]/contents/new/page.tsx
+++ b/src/app/(dashboard)/services/[serviceId]/apis/[apiId]/contents/new/page.tsx
@@ -1,5 +1,6 @@
 import { notFound } from "next/navigation";
 import { getSchemaFields } from "@/features/content-hub/manage-schema/query";
+import { getCustomFields } from "@/features/content-hub/manage-custom-fields/query";
 import type { SchemaFieldDef } from "@/features/content-hub/manage-content/components/field-renderers";
 
 import { ContentEditorWrapper } from "./editor-wrapper";
@@ -11,7 +12,10 @@ export default async function NewContentPage({
 }) {
   const { serviceId, apiId } = await params;
 
-  const fields = await getSchemaFields(apiId);
+  const [fields, customFieldList] = await Promise.all([
+    getSchemaFields(apiId),
+    getCustomFields(apiId),
+  ]);
 
   if (fields.length === 0) {
     notFound();
@@ -34,6 +38,7 @@ export default async function NewContentPage({
       apiId={apiId}
       schemaFields={schemaFields}
       isNew
+      customFields={customFieldList}
     />
   );
 }

--- a/src/app/(dashboard)/services/[serviceId]/apis/[apiId]/schema/page.tsx
+++ b/src/app/(dashboard)/services/[serviceId]/apis/[apiId]/schema/page.tsx
@@ -1,5 +1,6 @@
 import { notFound } from "next/navigation";
-import { getApiSchema } from "@/features/content-hub/manage-schema/query";
+import { getApiSchema, getApiSchemasByService } from "@/features/content-hub/manage-schema/query";
+import { getCustomFields } from "@/features/content-hub/manage-custom-fields/query";
 import type { FieldItem } from "@/features/content-hub/manage-schema/components/sortable-field-list";
 
 import { SchemaBuilderWrapper } from "./schema-builder-wrapper";
@@ -11,7 +12,11 @@ export default async function SchemaPage({
 }) {
   const { serviceId, apiId } = await params;
 
-  const schema = await getApiSchema(apiId);
+  const [schema, apiSchemas, customFieldList] = await Promise.all([
+    getApiSchema(apiId),
+    getApiSchemasByService(serviceId),
+    getCustomFields(apiId),
+  ]);
 
   if (!schema) {
     notFound();
@@ -32,6 +37,8 @@ export default async function SchemaPage({
       apiId={apiId}
       schemaName={schema.name}
       initialFields={fields}
+      apiSchemas={apiSchemas}
+      customFields={customFieldList}
     />
   );
 }

--- a/src/app/(dashboard)/services/[serviceId]/apis/[apiId]/schema/schema-builder-wrapper.tsx
+++ b/src/app/(dashboard)/services/[serviceId]/apis/[apiId]/schema/schema-builder-wrapper.tsx
@@ -4,6 +4,7 @@ import { useRouter } from "next/navigation";
 import { useTransition } from "react";
 import { toast } from "sonner";
 
+import type { ApiSchema, CustomField } from "@/features/content-hub/model";
 import { SchemaBuilder } from "@/features/content-hub/manage-schema/components/schema-builder";
 import type { FieldItem } from "@/features/content-hub/manage-schema/components/sortable-field-list";
 import {
@@ -18,6 +19,8 @@ interface SchemaBuilderWrapperProps {
   apiId: string;
   schemaName: string;
   initialFields: FieldItem[];
+  apiSchemas?: ApiSchema[];
+  customFields?: CustomField[];
 }
 
 export function SchemaBuilderWrapper({
@@ -25,6 +28,8 @@ export function SchemaBuilderWrapper({
   apiId,
   schemaName,
   initialFields,
+  apiSchemas,
+  customFields,
 }: SchemaBuilderWrapperProps) {
   const router = useRouter();
   const [isPending, startTransition] = useTransition();
@@ -104,6 +109,10 @@ export function SchemaBuilderWrapper({
       initialFields={initialFields}
       onSave={handleSave}
       isPending={isPending}
+      serviceId={serviceId}
+      apiSchemaId={apiId}
+      apiSchemas={apiSchemas}
+      customFields={customFields}
     />
   );
 }

--- a/src/features/content-hub/manage-content/components/content-editor.tsx
+++ b/src/features/content-hub/manage-content/components/content-editor.tsx
@@ -1,10 +1,11 @@
 "use client";
 
-import { useCallback, useTransition } from "react";
+import { createContext, useCallback, useTransition } from "react";
 
 import { Card, CardContent, CardHeader, CardTitle } from "@/shared/ui/card";
 import { Form } from "@/shared/ui/form";
 
+import type { CustomField } from "@/features/content-hub/model";
 import { useContentForm } from "../use-content-form";
 
 import {
@@ -13,6 +14,8 @@ import {
 } from "./field-renderers";
 import { PublishControls } from "./publish-controls";
 
+export const CustomFieldsContext = createContext<CustomField[]>([]);
+
 interface ContentEditorProps {
   schemaFields: SchemaFieldDef[];
   initialData?: Record<string, unknown> | null;
@@ -20,6 +23,7 @@ interface ContentEditorProps {
   isNew?: boolean;
   onSaveDraft: (data: Record<string, unknown>) => void | Promise<void>;
   onPublish: (data: Record<string, unknown>) => void | Promise<void>;
+  customFields?: CustomField[];
 }
 
 export function ContentEditor({
@@ -29,6 +33,7 @@ export function ContentEditor({
   isNew,
   onSaveDraft,
   onPublish,
+  customFields = [],
 }: ContentEditorProps) {
   const { form, getFormData } = useContentForm({
     fields: schemaFields,
@@ -52,41 +57,43 @@ export function ContentEditor({
   }, [form, onPublish]);
 
   return (
-    <div className="grid grid-cols-1 gap-6 p-6 lg:grid-cols-[1fr_320px]">
-      <Card>
-        <CardHeader>
-          <CardTitle>
-            {isNew ? "コンテンツ作成" : "コンテンツ編集"}
-          </CardTitle>
-        </CardHeader>
-        <CardContent>
-          <Form {...form}>
-            <form className="space-y-6">
-              {schemaFields.map((field) => (
-                <FieldRenderer
-                  key={field.id}
-                  field={field}
-                  control={form.control}
-                />
-              ))}
-              {schemaFields.length === 0 && (
-                <p className="text-muted-foreground py-8 text-center text-sm">
-                  スキーマにフィールドが定義されていません
-                </p>
-              )}
-            </form>
-          </Form>
-        </CardContent>
-      </Card>
+    <CustomFieldsContext value={customFields}>
+      <div className="grid grid-cols-1 gap-6 p-6 lg:grid-cols-[1fr_320px]">
+        <Card>
+          <CardHeader>
+            <CardTitle>
+              {isNew ? "コンテンツ作成" : "コンテンツ編集"}
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <Form {...form}>
+              <form className="space-y-6">
+                {schemaFields.map((field) => (
+                  <FieldRenderer
+                    key={field.id}
+                    field={field}
+                    control={form.control}
+                  />
+                ))}
+                {schemaFields.length === 0 && (
+                  <p className="text-muted-foreground py-8 text-center text-sm">
+                    スキーマにフィールドが定義されていません
+                  </p>
+                )}
+              </form>
+            </Form>
+          </CardContent>
+        </Card>
 
-      <div className="sticky top-20 self-start">
-        <PublishControls
-          status={status}
-          onSaveDraft={handleSaveDraft}
-          onPublish={handlePublish}
-          isPending={isPending}
-        />
+        <div className="sticky top-20 self-start">
+          <PublishControls
+            status={status}
+            onSaveDraft={handleSaveDraft}
+            onPublish={handlePublish}
+            isPending={isPending}
+          />
+        </div>
       </div>
-    </div>
+    </CustomFieldsContext>
   );
 }

--- a/src/features/content-hub/manage-content/use-content-form.ts
+++ b/src/features/content-hub/manage-content/use-content-form.ts
@@ -16,10 +16,19 @@ function buildZodSchema(fields: SchemaFieldDef[]) {
     switch (field.kind) {
       case "text":
       case "textArea":
-      case "select":
         fieldSchema = field.required
           ? z.string().min(1, `${field.name}は必須です`)
           : z.string().optional();
+        break;
+      case "richEditorV2":
+        fieldSchema = field.required
+          ? z.string().min(1, `${field.name}は必須です`)
+          : z.string().optional();
+        break;
+      case "select":
+        fieldSchema = field.required
+          ? z.array(z.string()).min(1, `${field.name}は必須です`)
+          : z.array(z.string()).optional();
         break;
       case "number":
         fieldSchema = field.required
@@ -33,6 +42,15 @@ function buildZodSchema(fields: SchemaFieldDef[]) {
         fieldSchema = field.required
           ? z.string().min(1, `${field.name}は必須です`)
           : z.string().optional();
+        break;
+      case "file":
+      case "iframe":
+        fieldSchema = field.required
+          ? z.unknown().refine(
+              (val) => val != null && val !== "",
+              `${field.name}は必須です`,
+            )
+          : z.unknown().optional();
         break;
       default:
         fieldSchema = z.unknown().optional();
@@ -60,15 +78,22 @@ function buildDefaultValues(
     switch (field.kind) {
       case "text":
       case "textArea":
-      case "select":
+      case "richEditorV2":
       case "date":
         defaults[field.fieldId] = "";
+        break;
+      case "select":
+        defaults[field.fieldId] = [];
         break;
       case "number":
         defaults[field.fieldId] = 0;
         break;
       case "boolean":
         defaults[field.fieldId] = false;
+        break;
+      case "file":
+      case "iframe":
+        defaults[field.fieldId] = null;
         break;
       default:
         defaults[field.fieldId] = undefined;

--- a/src/features/content-hub/manage-schema/components/field-editor.tsx
+++ b/src/features/content-hub/manage-schema/components/field-editor.tsx
@@ -1,11 +1,13 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useForm, useWatch } from "react-hook-form";
 import { z } from "zod";
+import { Plus, Trash2 } from "lucide-react";
 
 import { Button } from "@/shared/ui/button";
+import { Checkbox } from "@/shared/ui/checkbox";
 import {
   Form,
   FormControl,
@@ -15,6 +17,14 @@ import {
   FormMessage,
 } from "@/shared/ui/form";
 import { Input } from "@/shared/ui/input";
+import { Label } from "@/shared/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/shared/ui/select";
 import {
   Sheet,
   SheetContent,
@@ -23,10 +33,9 @@ import {
   SheetTitle,
 } from "@/shared/ui/sheet";
 import { Switch } from "@/shared/ui/switch";
-import { Textarea } from "@/shared/ui/textarea";
 
+import type { ApiSchema, CustomField } from "@/features/content-hub/model";
 import { FieldTypePicker } from "./field-type-picker";
-import { SubFieldEditor, type SubFieldDef } from "./sub-field-editor";
 
 const fieldSchema = z.object({
   name: z.string().min(1, "表示名は必須です"),
@@ -40,8 +49,6 @@ const fieldSchema = z.object({
   kind: z.string().min(1, "型を選択してください"),
   required: z.boolean(),
   description: z.string().optional(),
-  selectOptions: z.string().optional(),
-  multipleSelect: z.boolean().optional(),
 });
 
 type FieldFormValues = z.infer<typeof fieldSchema>;
@@ -56,39 +63,60 @@ export interface FieldEditorData {
   validationRules?: unknown;
 }
 
+interface SelectItemEntry {
+  id: string;
+  value: string;
+}
+
+interface SizeLimit {
+  min?: number;
+  max?: number;
+}
+
 interface FieldEditorProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   initialData?: FieldEditorData | null;
   onSave: (data: FieldEditorData) => void;
+  formKey?: number;
+  serviceId?: string;
+  apiSchemaId?: string;
+  apiSchemas?: ApiSchema[];
+  customFields?: CustomField[];
 }
 
-interface RepeaterRules {
-  subFields?: SubFieldDef[];
+function handleNumberInput(
+  setter: (fn: (prev: SizeLimit) => SizeLimit) => void,
+  key: "min" | "max",
+  rawValue: string,
+) {
+  if (rawValue === "") {
+    setter((prev) => ({ ...prev, [key]: undefined }));
+    return;
+  }
+  const num = Number(rawValue);
+  if (!Number.isNaN(num)) {
+    setter((prev) => ({ ...prev, [key]: num }));
+  }
 }
 
-interface SelectRules {
-  options?: string[];
-  multipleSelect?: boolean;
-}
-
-function parseSubFields(data: FieldEditorData | null | undefined): SubFieldDef[] {
-  if (!data || data.kind !== "repeater") return [];
-  const rules = data.validationRules as RepeaterRules | null;
-  return (rules?.subFields ?? []).map((sf) => ({
-    id: sf.id ?? sf.fieldId,
-    fieldId: sf.fieldId,
-    name: sf.name,
-    kind: sf.kind ?? ((sf as unknown as Record<string, unknown>).mycmsKind as string) ?? "text",
-    required: sf.required ?? false,
-    description: sf.description,
-    validationRules: sf.validationRules,
-  }));
-}
-
-function parseSelectRules(data: FieldEditorData | null | undefined): SelectRules | null {
-  if (!data || data.kind !== "select") return null;
-  return data.validationRules as SelectRules | null;
+function parseSelectItems(
+  data: FieldEditorData | null | undefined,
+): { items: SelectItemEntry[]; multipleSelect: boolean } {
+  if (!data || data.kind !== "select")
+    return { items: [], multipleSelect: false };
+  const rules = (data.validationRules ?? {}) as Record<string, unknown>;
+  const items = rules.selectItems as SelectItemEntry[] | undefined;
+  const legacyOptions = rules.options as string[] | undefined;
+  const selectItems = items
+    ? items
+    : legacyOptions
+      ? legacyOptions.map((o) => ({ id: crypto.randomUUID(), value: o }))
+      : [];
+  return {
+    items: selectItems,
+    multipleSelect: (rules.multipleSelect as boolean) ?? false,
+  };
 }
 
 export function FieldEditor({
@@ -96,11 +124,122 @@ export function FieldEditor({
   onOpenChange,
   initialData,
   onSave,
+  formKey,
+  apiSchemas = [],
+  customFields = [],
 }: FieldEditorProps) {
-  const selectRules = parseSelectRules(initialData);
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent className="overflow-y-auto">
+        <SheetHeader>
+          <SheetTitle>
+            {initialData?.id ? "フィールド編集" : "フィールド追加"}
+          </SheetTitle>
+        </SheetHeader>
+        <FieldEditorForm
+          key={formKey}
+          initialData={initialData}
+          onSave={(data) => {
+            onSave(data);
+            onOpenChange(false);
+          }}
+          apiSchemas={apiSchemas}
+          customFields={customFields}
+        />
+      </SheetContent>
+    </Sheet>
+  );
+}
 
-  const [subFields, setSubFields] = useState<SubFieldDef[]>(() =>
-    parseSubFields(initialData),
+interface FieldEditorFormProps {
+  initialData?: FieldEditorData | null;
+  onSave: (data: FieldEditorData) => void;
+  apiSchemas: ApiSchema[];
+  customFields: CustomField[];
+}
+
+function FieldEditorForm({
+  initialData,
+  onSave,
+  apiSchemas,
+  customFields,
+}: FieldEditorFormProps) {
+  const parsedSelect = parseSelectItems(initialData);
+  const rules = (initialData?.validationRules ?? {}) as Record<
+    string,
+    unknown
+  >;
+  const kind = initialData?.kind;
+
+  const [selectItems, setSelectItems] = useState<SelectItemEntry[]>(
+    parsedSelect.items,
+  );
+  const [multipleSelect, setMultipleSelect] = useState(
+    parsedSelect.multipleSelect,
+  );
+
+  const [referencedApiEndpoint, setReferencedApiEndpoint] = useState(
+    kind === "relation" || kind === "relationList"
+      ? ((rules.referencedApiEndpoint as string) ?? "")
+      : "",
+  );
+
+  const [textUnique, setTextUnique] = useState(
+    kind === "text" ? ((rules.unique as boolean) ?? false) : false,
+  );
+  const [textPatternMatch, setTextPatternMatch] = useState(
+    kind === "text" ? ((rules.patternMatch as string) ?? "") : "",
+  );
+  const [textSizeLimit, setTextSizeLimit] = useState<SizeLimit>(
+    kind === "text"
+      ? {
+          min: (rules.textSizeLimit as SizeLimit | undefined)?.min,
+          max: (rules.textSizeLimit as SizeLimit | undefined)?.max,
+        }
+      : {},
+  );
+
+  const [textAreaSizeLimit, setTextAreaSizeLimit] = useState<SizeLimit>(
+    kind === "textArea"
+      ? {
+          min: (rules.textSizeLimit as SizeLimit | undefined)?.min,
+          max: (rules.textSizeLimit as SizeLimit | undefined)?.max,
+        }
+      : {},
+  );
+
+  const [numberSizeLimit, setNumberSizeLimit] = useState<SizeLimit>(
+    kind === "number"
+      ? {
+          min: (rules.numberSizeLimit as SizeLimit | undefined)?.min,
+          max: (rules.numberSizeLimit as SizeLimit | undefined)?.max,
+        }
+      : {},
+  );
+
+  const [selectedCustomFieldCreatedAt, setSelectedCustomFieldCreatedAt] =
+    useState(
+      kind === "custom"
+        ? ((rules.customFieldCreatedAt as string) ?? "")
+        : "",
+    );
+
+  const [repeaterCustomFieldIds, setRepeaterCustomFieldIds] = useState<
+    string[]
+  >(kind === "repeater" ? ((rules.customFieldIds as string[]) ?? []) : []);
+  const [repeaterMinCount, setRepeaterMinCount] = useState<
+    number | undefined
+  >(
+    kind === "repeater"
+      ? ((rules.minCount as number | undefined) ?? undefined)
+      : undefined,
+  );
+  const [repeaterMaxCount, setRepeaterMaxCount] = useState<
+    number | undefined
+  >(
+    kind === "repeater"
+      ? ((rules.maxCount as number | undefined) ?? undefined)
+      : undefined,
   );
 
   const form = useForm<FieldFormValues>({
@@ -111,26 +250,8 @@ export function FieldEditor({
       kind: initialData?.kind ?? "text",
       required: initialData?.required ?? false,
       description: initialData?.description ?? "",
-      selectOptions: selectRules?.options?.join("\n") ?? "",
-      multipleSelect: selectRules?.multipleSelect ?? false,
     },
   });
-
-  useEffect(() => {
-    if (open) {
-      const rules = parseSelectRules(initialData);
-      form.reset({
-        name: initialData?.name ?? "",
-        fieldId: initialData?.fieldId ?? "",
-        kind: initialData?.kind ?? "text",
-        required: initialData?.required ?? false,
-        description: initialData?.description ?? "",
-        selectOptions: rules?.options?.join("\n") ?? "",
-        multipleSelect: rules?.multipleSelect ?? false,
-      });
-      setSubFields(parseSubFields(initialData));
-    }
-  }, [open, initialData, form]);
 
   const selectedKind = useWatch({ control: form.control, name: "kind" });
 
@@ -144,175 +265,499 @@ export function FieldEditor({
       description: values.description,
     };
 
-    if (values.kind === "select" && values.selectOptions) {
-      data.validationRules = {
-        options: values.selectOptions
-          .split("\n")
-          .map((s) => s.trim())
-          .filter(Boolean),
-        ...(values.multipleSelect ? { multipleSelect: true } : {}),
-      };
-    }
-
-    if (values.kind === "repeater") {
-      data.validationRules = {
-        subFields: subFields.map((sf) => ({
-          fieldId: sf.fieldId,
-          name: sf.name,
-          kind: sf.kind,
-          required: sf.required ?? false,
-          description: sf.description,
-          validationRules: sf.validationRules,
-        })),
-      };
+    switch (values.kind) {
+      case "select": {
+        const filteredItems = selectItems.filter((item) =>
+          item.value.trim(),
+        );
+        data.validationRules = {
+          selectItems: filteredItems,
+          multipleSelect,
+          selectInitialValue: [],
+        };
+        break;
+      }
+      case "relation":
+      case "relationList": {
+        if (referencedApiEndpoint) {
+          data.validationRules = { referencedApiEndpoint };
+        }
+        break;
+      }
+      case "text": {
+        const textRules: Record<string, unknown> = {};
+        if (textUnique) textRules.unique = true;
+        if (textPatternMatch.trim())
+          textRules.patternMatch = textPatternMatch.trim();
+        const limit: Record<string, number> = {};
+        if (textSizeLimit.min != null) limit.min = textSizeLimit.min;
+        if (textSizeLimit.max != null) limit.max = textSizeLimit.max;
+        if (Object.keys(limit).length > 0) textRules.textSizeLimit = limit;
+        if (Object.keys(textRules).length > 0)
+          data.validationRules = textRules;
+        break;
+      }
+      case "textArea": {
+        const limit: Record<string, number> = {};
+        if (textAreaSizeLimit.min != null)
+          limit.min = textAreaSizeLimit.min;
+        if (textAreaSizeLimit.max != null)
+          limit.max = textAreaSizeLimit.max;
+        if (Object.keys(limit).length > 0) {
+          data.validationRules = { textSizeLimit: limit };
+        }
+        break;
+      }
+      case "number": {
+        const limit: Record<string, number> = {};
+        if (numberSizeLimit.min != null) limit.min = numberSizeLimit.min;
+        if (numberSizeLimit.max != null) limit.max = numberSizeLimit.max;
+        if (Object.keys(limit).length > 0) {
+          data.validationRules = { numberSizeLimit: limit };
+        }
+        break;
+      }
+      case "custom": {
+        if (selectedCustomFieldCreatedAt) {
+          data.validationRules = {
+            customFieldCreatedAt: selectedCustomFieldCreatedAt,
+          };
+        }
+        break;
+      }
+      case "repeater": {
+        const repeaterRules: Record<string, unknown> = {};
+        if (repeaterCustomFieldIds.length > 0) {
+          repeaterRules.customFieldIds = repeaterCustomFieldIds;
+        }
+        if (repeaterMinCount != null)
+          repeaterRules.minCount = repeaterMinCount;
+        if (repeaterMaxCount != null)
+          repeaterRules.maxCount = repeaterMaxCount;
+        if (Object.keys(repeaterRules).length > 0)
+          data.validationRules = repeaterRules;
+        break;
+      }
     }
 
     onSave(data);
-    onOpenChange(false);
     form.reset();
   }
 
+  function addSelectItem() {
+    setSelectItems((prev) => [
+      ...prev,
+      { id: crypto.randomUUID(), value: "" },
+    ]);
+  }
+
+  function removeSelectItem(index: number) {
+    setSelectItems((prev) => prev.filter((_, i) => i !== index));
+  }
+
+  function updateSelectItem(index: number, value: string) {
+    setSelectItems((prev) =>
+      prev.map((item, i) => (i === index ? { ...item, value } : item)),
+    );
+  }
+
+  function toggleRepeaterCustomField(cfId: string) {
+    setRepeaterCustomFieldIds((prev) =>
+      prev.includes(cfId)
+        ? prev.filter((id) => id !== cfId)
+        : [...prev, cfId],
+    );
+  }
+
   return (
-    <Sheet open={open} onOpenChange={onOpenChange}>
-      <SheetContent className="overflow-y-auto">
-        <SheetHeader>
-          <SheetTitle>
-            {initialData?.id ? "フィールド編集" : "フィールド追加"}
-          </SheetTitle>
-        </SheetHeader>
-        <Form {...form}>
-          <form
-            onSubmit={form.handleSubmit(handleSubmit)}
-            className="space-y-4 p-4"
-          >
-            <FormField
-              control={form.control}
-              name="name"
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>表示名</FormLabel>
-                  <FormControl>
-                    <Input {...field} placeholder="タイトル" />
-                  </FormControl>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
+    <Form {...form}>
+      <form
+        onSubmit={form.handleSubmit(handleSubmit)}
+        className="space-y-4 p-4"
+      >
+        <FormField
+          control={form.control}
+          name="name"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>表示名</FormLabel>
+              <FormControl>
+                <Input {...field} placeholder="タイトル" />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
 
-            <FormField
-              control={form.control}
-              name="fieldId"
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>フィールドID</FormLabel>
-                  <FormControl>
-                    <Input {...field} placeholder="title" />
-                  </FormControl>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
+        <FormField
+          control={form.control}
+          name="fieldId"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>フィールドID</FormLabel>
+              <FormControl>
+                <Input {...field} placeholder="title" />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
 
-            <FormField
-              control={form.control}
-              name="kind"
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>型</FormLabel>
-                  <FormControl>
-                    <FieldTypePicker
-                      value={field.value}
-                      onChange={field.onChange}
-                      disabled={!!initialData?.id}
-                    />
-                  </FormControl>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
-
-            <FormField
-              control={form.control}
-              name="required"
-              render={({ field }) => (
-                <FormItem className="flex items-center justify-between rounded-lg border p-3">
-                  <FormLabel>必須</FormLabel>
-                  <FormControl>
-                    <Switch
-                      checked={field.value}
-                      onCheckedChange={field.onChange}
-                    />
-                  </FormControl>
-                </FormItem>
-              )}
-            />
-
-            <FormField
-              control={form.control}
-              name="description"
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>説明</FormLabel>
-                  <FormControl>
-                    <Input {...field} placeholder="フィールドの説明" />
-                  </FormControl>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
-
-            {selectedKind === "select" && (
-              <>
-                <FormField
-                  control={form.control}
-                  name="selectOptions"
-                  render={({ field }) => (
-                    <FormItem>
-                      <FormLabel>選択肢（改行区切り）</FormLabel>
-                      <FormControl>
-                        <Textarea
-                          {...field}
-                          placeholder={"オプション1\nオプション2\nオプション3"}
-                          rows={4}
-                        />
-                      </FormControl>
-                      <FormMessage />
-                    </FormItem>
-                  )}
+        <FormField
+          control={form.control}
+          name="kind"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>型</FormLabel>
+              <FormControl>
+                <FieldTypePicker
+                  value={field.value}
+                  onChange={field.onChange}
+                  disabled={!!initialData?.id}
                 />
-                <FormField
-                  control={form.control}
-                  name="multipleSelect"
-                  render={({ field }) => (
-                    <FormItem className="flex items-center justify-between rounded-lg border p-3">
-                      <FormLabel>複数選択</FormLabel>
-                      <FormControl>
-                        <Switch
-                          checked={field.value}
-                          onCheckedChange={field.onChange}
-                        />
-                      </FormControl>
-                    </FormItem>
-                  )}
-                />
-              </>
-            )}
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
 
-            {selectedKind === "repeater" && (
-              <SubFieldEditor
-                subFields={subFields}
-                onChange={setSubFields}
+        <FormField
+          control={form.control}
+          name="required"
+          render={({ field }) => (
+            <FormItem className="flex items-center justify-between rounded-lg border p-3">
+              <FormLabel>必須</FormLabel>
+              <FormControl>
+                <Switch
+                  checked={field.value}
+                  onCheckedChange={field.onChange}
+                />
+              </FormControl>
+            </FormItem>
+          )}
+        />
+
+        <FormField
+          control={form.control}
+          name="description"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>説明</FormLabel>
+              <FormControl>
+                <Input {...field} placeholder="フィールドの説明" />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        {selectedKind === "select" && (
+          <div className="space-y-3 rounded-lg border p-3">
+            <Label className="text-sm font-medium">選択肢</Label>
+            {selectItems.map((item, index) => (
+              <div key={item.id} className="flex items-center gap-2">
+                <Input
+                  value={item.value}
+                  onChange={(e) =>
+                    updateSelectItem(index, e.target.value)
+                  }
+                  placeholder={`選択肢 ${index + 1}`}
+                  className="flex-1"
+                />
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon"
+                  onClick={() => removeSelectItem(index)}
+                >
+                  <Trash2 className="h-4 w-4" />
+                </Button>
+              </div>
+            ))}
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              className="w-full"
+              onClick={addSelectItem}
+            >
+              <Plus className="mr-1 h-4 w-4" />
+              選択肢を追加
+            </Button>
+            <div className="flex items-center justify-between rounded-lg border p-3">
+              <Label className="text-sm">複数選択</Label>
+              <Switch
+                checked={multipleSelect}
+                onCheckedChange={setMultipleSelect}
               />
-            )}
+            </div>
+          </div>
+        )}
 
-            <SheetFooter>
-              <Button type="submit">
-                {initialData?.id ? "更新" : "追加"}
-              </Button>
-            </SheetFooter>
-          </form>
-        </Form>
-      </SheetContent>
-    </Sheet>
+        {(selectedKind === "relation" ||
+          selectedKind === "relationList") && (
+          <div className="space-y-3 rounded-lg border p-3">
+            <Label className="text-sm font-medium">参照先API</Label>
+            {apiSchemas.length > 0 ? (
+              <Select
+                value={referencedApiEndpoint || undefined}
+                onValueChange={setReferencedApiEndpoint}
+              >
+                <SelectTrigger className="w-full">
+                  <SelectValue placeholder="APIエンドポイントを選択" />
+                </SelectTrigger>
+                <SelectContent>
+                  {apiSchemas.map((schema) => (
+                    <SelectItem
+                      key={schema.id}
+                      value={schema.endpoint}
+                    >
+                      {schema.name} ({schema.endpoint})
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            ) : (
+              <p className="text-muted-foreground text-sm">
+                利用可能なAPIスキーマがありません
+              </p>
+            )}
+          </div>
+        )}
+
+        {selectedKind === "text" && (
+          <div className="space-y-3 rounded-lg border p-3">
+            <Label className="text-sm font-medium">バリデーション</Label>
+            <div className="flex items-center justify-between">
+              <Label className="text-sm">ユニーク</Label>
+              <Switch
+                checked={textUnique}
+                onCheckedChange={setTextUnique}
+              />
+            </div>
+            <div className="space-y-1">
+              <Label className="text-sm">パターン（正規表現）</Label>
+              <Input
+                value={textPatternMatch}
+                onChange={(e) => setTextPatternMatch(e.target.value)}
+                placeholder="^[a-z]+$"
+              />
+            </div>
+            <div className="grid grid-cols-2 gap-2">
+              <div className="space-y-1">
+                <Label className="text-sm">最小文字数</Label>
+                <Input
+                  type="number"
+                  value={textSizeLimit.min ?? ""}
+                  onChange={(e) =>
+                    handleNumberInput(
+                      setTextSizeLimit,
+                      "min",
+                      e.target.value,
+                    )
+                  }
+                />
+              </div>
+              <div className="space-y-1">
+                <Label className="text-sm">最大文字数</Label>
+                <Input
+                  type="number"
+                  value={textSizeLimit.max ?? ""}
+                  onChange={(e) =>
+                    handleNumberInput(
+                      setTextSizeLimit,
+                      "max",
+                      e.target.value,
+                    )
+                  }
+                />
+              </div>
+            </div>
+          </div>
+        )}
+
+        {selectedKind === "textArea" && (
+          <div className="space-y-3 rounded-lg border p-3">
+            <Label className="text-sm font-medium">バリデーション</Label>
+            <div className="grid grid-cols-2 gap-2">
+              <div className="space-y-1">
+                <Label className="text-sm">最小文字数</Label>
+                <Input
+                  type="number"
+                  value={textAreaSizeLimit.min ?? ""}
+                  onChange={(e) =>
+                    handleNumberInput(
+                      setTextAreaSizeLimit,
+                      "min",
+                      e.target.value,
+                    )
+                  }
+                />
+              </div>
+              <div className="space-y-1">
+                <Label className="text-sm">最大文字数</Label>
+                <Input
+                  type="number"
+                  value={textAreaSizeLimit.max ?? ""}
+                  onChange={(e) =>
+                    handleNumberInput(
+                      setTextAreaSizeLimit,
+                      "max",
+                      e.target.value,
+                    )
+                  }
+                />
+              </div>
+            </div>
+          </div>
+        )}
+
+        {selectedKind === "number" && (
+          <div className="space-y-3 rounded-lg border p-3">
+            <Label className="text-sm font-medium">バリデーション</Label>
+            <div className="grid grid-cols-2 gap-2">
+              <div className="space-y-1">
+                <Label className="text-sm">最小値</Label>
+                <Input
+                  type="number"
+                  value={numberSizeLimit.min ?? ""}
+                  onChange={(e) =>
+                    handleNumberInput(
+                      setNumberSizeLimit,
+                      "min",
+                      e.target.value,
+                    )
+                  }
+                />
+              </div>
+              <div className="space-y-1">
+                <Label className="text-sm">最大値</Label>
+                <Input
+                  type="number"
+                  value={numberSizeLimit.max ?? ""}
+                  onChange={(e) =>
+                    handleNumberInput(
+                      setNumberSizeLimit,
+                      "max",
+                      e.target.value,
+                    )
+                  }
+                />
+              </div>
+            </div>
+          </div>
+        )}
+
+        {selectedKind === "custom" && (
+          <div className="space-y-3 rounded-lg border p-3">
+            <Label className="text-sm font-medium">
+              カスタムフィールド
+            </Label>
+            {customFields.length > 0 ? (
+              <Select
+                value={selectedCustomFieldCreatedAt || undefined}
+                onValueChange={setSelectedCustomFieldCreatedAt}
+              >
+                <SelectTrigger className="w-full">
+                  <SelectValue placeholder="カスタムフィールドを選択" />
+                </SelectTrigger>
+                <SelectContent>
+                  {customFields.map((cf) => {
+                    const createdAtValue =
+                      cf.createdAt instanceof Date
+                        ? cf.createdAt.toISOString()
+                        : String(cf.createdAt);
+                    return (
+                      <SelectItem
+                        key={cf.id}
+                        value={createdAtValue}
+                      >
+                        {cf.name}
+                      </SelectItem>
+                    );
+                  })}
+                </SelectContent>
+              </Select>
+            ) : (
+              <p className="text-muted-foreground text-sm">
+                カスタムフィールドがありません
+              </p>
+            )}
+          </div>
+        )}
+
+        {selectedKind === "repeater" && (
+          <div className="space-y-3 rounded-lg border p-3">
+            <Label className="text-sm font-medium">
+              カスタムフィールド
+            </Label>
+            {customFields.length > 0 ? (
+              <div className="space-y-2">
+                {customFields.map((cf) => (
+                  <div
+                    key={cf.id}
+                    className="flex items-center gap-2"
+                  >
+                    <Checkbox
+                      id={`repeater-cf-${cf.id}`}
+                      checked={repeaterCustomFieldIds.includes(cf.id)}
+                      onCheckedChange={() =>
+                        toggleRepeaterCustomField(cf.id)
+                      }
+                    />
+                    <Label
+                      htmlFor={`repeater-cf-${cf.id}`}
+                      className="text-sm font-normal"
+                    >
+                      {cf.name}
+                    </Label>
+                  </div>
+                ))}
+              </div>
+            ) : (
+              <p className="text-muted-foreground text-sm">
+                カスタムフィールドがありません
+              </p>
+            )}
+            <div className="grid grid-cols-2 gap-2">
+              <div className="space-y-1">
+                <Label className="text-sm">最小件数</Label>
+                <Input
+                  type="number"
+                  value={repeaterMinCount ?? ""}
+                  onChange={(e) =>
+                    setRepeaterMinCount(
+                      e.target.value === ""
+                        ? undefined
+                        : Number(e.target.value),
+                    )
+                  }
+                />
+              </div>
+              <div className="space-y-1">
+                <Label className="text-sm">最大件数</Label>
+                <Input
+                  type="number"
+                  value={repeaterMaxCount ?? ""}
+                  onChange={(e) =>
+                    setRepeaterMaxCount(
+                      e.target.value === ""
+                        ? undefined
+                        : Number(e.target.value),
+                    )
+                  }
+                />
+              </div>
+            </div>
+          </div>
+        )}
+
+        <SheetFooter>
+          <Button type="submit">
+            {initialData?.id ? "更新" : "追加"}
+          </Button>
+        </SheetFooter>
+      </form>
+    </Form>
   );
 }

--- a/src/features/content-hub/manage-schema/components/schema-builder.tsx
+++ b/src/features/content-hub/manage-schema/components/schema-builder.tsx
@@ -12,6 +12,8 @@ import {
   CardTitle,
 } from "@/shared/ui/card";
 
+import type { ApiSchema, CustomField } from "@/features/content-hub/model";
+
 import {
   FieldEditor,
   type FieldEditorData,
@@ -26,6 +28,10 @@ interface SchemaBuilderProps {
   initialFields: FieldItem[];
   onSave: (fields: FieldItem[]) => void;
   isPending?: boolean;
+  serviceId?: string;
+  apiSchemaId?: string;
+  apiSchemas?: ApiSchema[];
+  customFields?: CustomField[];
 }
 
 export function SchemaBuilder({
@@ -33,16 +39,22 @@ export function SchemaBuilder({
   initialFields,
   onSave,
   isPending,
+  serviceId,
+  apiSchemaId,
+  apiSchemas,
+  customFields,
 }: SchemaBuilderProps) {
   const [fields, setFields] = useState<FieldItem[]>(initialFields);
   const [editingField, setEditingField] = useState<FieldEditorData | null>(
     null
   );
   const [isEditorOpen, setIsEditorOpen] = useState(false);
+  const [editorFormKey, setEditorFormKey] = useState(0);
 
   const handleAddField = useCallback(() => {
     setEditingField(null);
     setIsEditorOpen(true);
+    setEditorFormKey((prev) => prev + 1);
   }, []);
 
   const handleEditField = useCallback((field: FieldItem) => {
@@ -55,6 +67,7 @@ export function SchemaBuilder({
       validationRules: field.validationRules,
     });
     setIsEditorOpen(true);
+    setEditorFormKey((prev) => prev + 1);
   }, []);
 
   const handleDeleteField = useCallback(
@@ -151,6 +164,11 @@ export function SchemaBuilder({
         onOpenChange={setIsEditorOpen}
         initialData={editingField}
         onSave={handleSaveField}
+        formKey={editorFormKey}
+        serviceId={serviceId}
+        apiSchemaId={apiSchemaId}
+        apiSchemas={apiSchemas}
+        customFields={customFields}
       />
     </>
   );

--- a/src/features/content-hub/manage-schema/migrate-data.ts
+++ b/src/features/content-hub/manage-schema/migrate-data.ts
@@ -1,0 +1,160 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { db } from "@/db";
+import { apiSchemas, customFields, schemaFields } from "@/db/schema";
+import type { ActionResult } from "@/shared/types";
+import { requirePermission } from "@/shared/lib/auth-guard";
+import { eq, and, sql } from "drizzle-orm";
+
+interface SubFieldDef {
+  fieldId: string;
+  name: string;
+  kind: string;
+  required: boolean;
+  description?: string | null;
+  validationRules?: unknown;
+}
+
+export async function migrateSelectFields(
+  serviceId: string,
+): Promise<ActionResult> {
+  try {
+    await requirePermission(serviceId, "schema.update");
+
+    const selectFields = await db
+      .select({
+        sfId: schemaFields.id,
+        fieldId: schemaFields.fieldId,
+        apiSchemaId: schemaFields.apiSchemaId,
+      })
+      .from(schemaFields)
+      .innerJoin(apiSchemas, eq(schemaFields.apiSchemaId, apiSchemas.id))
+      .where(
+        and(eq(apiSchemas.serviceId, serviceId), eq(schemaFields.kind, "select")),
+      );
+
+    for (const sf of selectFields) {
+      await db.execute(sql`
+        UPDATE content_hub.contents
+        SET data = jsonb_set(
+          data,
+          ${sql.raw(`'{${sf.fieldId}}'`)},
+          to_jsonb(ARRAY[data->>${sf.fieldId}])
+        )
+        WHERE api_schema_id = ${sf.apiSchemaId}
+          AND data ? ${sf.fieldId}
+          AND jsonb_typeof(data->${sf.fieldId}) = 'string'
+      `);
+
+      await db.execute(sql`
+        UPDATE content_hub.contents
+        SET draft_data = jsonb_set(
+          draft_data,
+          ${sql.raw(`'{${sf.fieldId}}'`)},
+          to_jsonb(ARRAY[draft_data->>${sf.fieldId}])
+        )
+        WHERE api_schema_id = ${sf.apiSchemaId}
+          AND draft_data ? ${sf.fieldId}
+          AND jsonb_typeof(draft_data->${sf.fieldId}) = 'string'
+      `);
+    }
+
+    revalidatePath("/", "layout");
+
+    return {
+      success: true,
+      data: undefined,
+    };
+  } catch (error) {
+    return {
+      success: false,
+      error:
+        error instanceof Error
+          ? error.message
+          : "セレクトフィールドの移行に失敗しました",
+    };
+  }
+}
+
+export async function migrateRepeaterToCustomFields(
+  serviceId: string,
+): Promise<ActionResult> {
+  try {
+    await requirePermission(serviceId, "schema.update");
+
+    const repeaterFields = await db
+      .select({
+        sfId: schemaFields.id,
+        fieldId: schemaFields.fieldId,
+        apiSchemaId: schemaFields.apiSchemaId,
+        validationRules: schemaFields.validationRules,
+      })
+      .from(schemaFields)
+      .innerJoin(apiSchemas, eq(schemaFields.apiSchemaId, apiSchemas.id))
+      .where(
+        and(
+          eq(apiSchemas.serviceId, serviceId),
+          eq(schemaFields.kind, "repeater"),
+        ),
+      );
+
+    for (const sf of repeaterFields) {
+      const rules = sf.validationRules as {
+        subFields?: SubFieldDef[];
+        customFieldIds?: string[];
+      } | null;
+
+      if (!rules?.subFields || rules.subFields.length === 0) continue;
+      if (rules.customFieldIds) continue;
+
+      const cfFieldId = `${sf.fieldId}_fields`;
+      const cfName = `${sf.fieldId} フィールド`;
+
+      const subFieldsForCf = rules.subFields.map((sub) => ({
+        idValue: crypto.randomUUID(),
+        fieldId: sub.fieldId,
+        name: sub.name,
+        kind: sub.kind,
+        required: sub.required ?? false,
+        description: sub.description ?? null,
+        validationRules: sub.validationRules ?? null,
+      }));
+
+      const [newCf] = await db
+        .insert(customFields)
+        .values({
+          apiSchemaId: sf.apiSchemaId,
+          fieldId: cfFieldId,
+          name: cfName,
+          fields: subFieldsForCf,
+        })
+        .returning({ id: customFields.id });
+
+      if (newCf) {
+        await db
+          .update(schemaFields)
+          .set({
+            validationRules: { customFieldIds: [newCf.id] },
+            updatedAt: new Date(),
+          })
+          .where(eq(schemaFields.id, sf.sfId));
+      }
+    }
+
+    revalidatePath("/", "layout");
+
+    return {
+      success: true,
+      data: undefined,
+    };
+  } catch (error) {
+    return {
+      success: false,
+      error:
+        error instanceof Error
+          ? error.message
+          : "リピーターフィールドの移行に失敗しました",
+    };
+  }
+}


### PR DESCRIPTION
## Summary

- **Field editor overhaul**: Replaced textarea-based select options with structured `selectItems [{id,value}]` format. Added relation/relationList `referencedApiEndpoint` dropdown. Added text/textArea/number validation rules (unique, pattern match, size limits). Added custom field template selection for `custom` kind. Changed repeater from inline SubFieldEditor to `customFieldIds` multi-select with min/max count.
- **Select field renderer**: Supports both legacy `options[]` and new `selectItems [{id,value}]` format. Always stores selected values as arrays (single select wraps in `[value]`).
- **Repeater field renderer**: Supports custom field templates via `customFieldIds` from `custom_fields` table. Maintains backward compat with legacy `subFields` format. Each repeater item includes a `fieldId` identifying the custom field template used. Multi-template selector when multiple custom fields are configured.
- **Content editor + context**: `CustomFieldsContext` provides custom field definitions to nested field renderers. All content pages (new + edit) fetch and pass custom fields.
- **use-content-form**: Select validates as `z.array(z.string())`, defaults to `[]`. Added `richEditorV2`, `file`, `iframe` cases.
- **Data migration**: Server actions for migrating select values (string→array) and repeater subFields (inline→custom_fields table).

Resolves #13

## Test plan

- [ ] Create a new API schema with select field using the new item editor UI
- [ ] Verify select field stores values as arrays in content
- [ ] Add relation field with `referencedApiEndpoint` selection
- [ ] Configure text field with unique, pattern, and size limit validation
- [ ] Create custom field templates, then add custom/repeater fields that reference them
- [ ] Verify repeater items include `fieldId` for the custom field template
- [ ] Test backward compat: existing schemas with legacy `options[]` and `subFields` still render correctly
- [ ] Run data migration actions on existing content
- [ ] `npm run build` passes with 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)