### PR TITLE
feat: API response serialization + schema import/export

### DIFF
--- a/src/app/(dashboard)/services/[serviceId]/apis/[apiId]/schema/schema-builder-wrapper.tsx
+++ b/src/app/(dashboard)/services/[serviceId]/apis/[apiId]/schema/schema-builder-wrapper.tsx
@@ -103,6 +103,10 @@ export function SchemaBuilderWrapper({
     });
   }
 
+  function handleImported() {
+    router.refresh();
+  }
+
   return (
     <SchemaBuilder
       schemaName={schemaName}
@@ -113,6 +117,7 @@ export function SchemaBuilderWrapper({
       apiSchemaId={apiId}
       apiSchemas={apiSchemas}
       customFields={customFields}
+      onImported={handleImported}
     />
   );
 }

--- a/src/features/content-hub/manage-schema/components/schema-builder.tsx
+++ b/src/features/content-hub/manage-schema/components/schema-builder.tsx
@@ -18,6 +18,8 @@ import {
   FieldEditor,
   type FieldEditorData,
 } from "./field-editor";
+import { SchemaExportButton } from "./schema-export-button";
+import { SchemaImportDialog } from "./schema-import-dialog";
 import {
   SortableFieldList,
   type FieldItem,
@@ -32,6 +34,7 @@ interface SchemaBuilderProps {
   apiSchemaId?: string;
   apiSchemas?: ApiSchema[];
   customFields?: CustomField[];
+  onImported?: () => void;
 }
 
 export function SchemaBuilder({
@@ -43,6 +46,7 @@ export function SchemaBuilder({
   apiSchemaId,
   apiSchemas,
   customFields,
+  onImported,
 }: SchemaBuilderProps) {
   const [fields, setFields] = useState<FieldItem[]>(initialFields);
   const [editingField, setEditingField] = useState<FieldEditorData | null>(
@@ -126,6 +130,20 @@ export function SchemaBuilder({
                 </CardDescription>
               </div>
               <div className="flex gap-2">
+                {apiSchemaId && serviceId && (
+                  <>
+                    <SchemaImportDialog
+                      apiSchemaId={apiSchemaId}
+                      serviceId={serviceId}
+                      onImported={onImported}
+                    />
+                    <SchemaExportButton
+                      apiSchemaId={apiSchemaId}
+                      serviceId={serviceId}
+                      schemaName={schemaName}
+                    />
+                  </>
+                )}
                 <Button variant="outline" onClick={handleAddField}>
                   <Plus className="size-4" />
                   フィールドを追加

--- a/src/features/content-hub/manage-schema/components/schema-export-button.tsx
+++ b/src/features/content-hub/manage-schema/components/schema-export-button.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { Download } from "lucide-react";
+import { useCallback, useState } from "react";
+
+import { Button } from "@/shared/ui/button";
+
+import { exportSchema } from "../export-action";
+
+interface SchemaExportButtonProps {
+  apiSchemaId: string;
+  serviceId: string;
+  schemaName: string;
+}
+
+export function SchemaExportButton({
+  apiSchemaId,
+  serviceId,
+  schemaName,
+}: SchemaExportButtonProps) {
+  const [isExporting, setIsExporting] = useState(false);
+
+  const handleExport = useCallback(async () => {
+    setIsExporting(true);
+    try {
+      const result = await exportSchema(apiSchemaId, serviceId);
+      if (!result.success) {
+        throw new Error(result.error);
+      }
+
+      const json = JSON.stringify(result.data, null, 2);
+      const blob = new Blob([json], { type: "application/json" });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = `${schemaName}-schema.json`;
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+      URL.revokeObjectURL(url);
+    } catch {
+      // Export failure is visible to user via the download not happening
+    } finally {
+      setIsExporting(false);
+    }
+  }, [apiSchemaId, serviceId, schemaName]);
+
+  return (
+    <Button variant="outline" onClick={handleExport} disabled={isExporting}>
+      <Download className="size-4" />
+      {isExporting ? "エクスポート中..." : "エクスポート"}
+    </Button>
+  );
+}

--- a/src/features/content-hub/manage-schema/components/schema-import-dialog.tsx
+++ b/src/features/content-hub/manage-schema/components/schema-import-dialog.tsx
@@ -1,0 +1,233 @@
+"use client";
+
+import { Upload } from "lucide-react";
+import { useCallback, useRef, useState } from "react";
+
+import { Badge } from "@/shared/ui/badge";
+import { Button } from "@/shared/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/shared/ui/dialog";
+import { Label } from "@/shared/ui/label";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/shared/ui/tabs";
+import { Textarea } from "@/shared/ui/textarea";
+
+import { FIELD_TYPES, type FieldKind } from "@/features/content-hub/field-types";
+
+import { schemaImportSchema, type SchemaImportInput } from "../schema-import-validator";
+import { importSchema } from "../import-action";
+
+interface SchemaImportDialogProps {
+  apiSchemaId: string;
+  serviceId: string;
+  onImported?: () => void;
+}
+
+export function SchemaImportDialog({
+  apiSchemaId,
+  serviceId,
+  onImported,
+}: SchemaImportDialogProps) {
+  const [open, setOpen] = useState(false);
+  const [jsonText, setJsonText] = useState("");
+  const [parsed, setParsed] = useState<SchemaImportInput | null>(null);
+  const [parseError, setParseError] = useState<string | null>(null);
+  const [isImporting, setIsImporting] = useState(false);
+  const [importError, setImportError] = useState<string | null>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const tryParse = useCallback((text: string) => {
+    setJsonText(text);
+    setParseError(null);
+    setParsed(null);
+    setImportError(null);
+
+    if (!text.trim()) return;
+
+    try {
+      const json = JSON.parse(text);
+      const result = schemaImportSchema.safeParse(json);
+      if (result.success) {
+        setParsed(result.data);
+      } else {
+        setParseError(result.error.issues.map((e) => e.message).join(", "));
+      }
+    } catch {
+      setParseError("無効なJSON形式です");
+    }
+  }, []);
+
+  const handleFileUpload = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const file = e.target.files?.[0];
+      if (!file) return;
+
+      const reader = new FileReader();
+      reader.onload = (event) => {
+        const text = event.target?.result;
+        if (typeof text === "string") {
+          tryParse(text);
+        }
+      };
+      reader.readAsText(file);
+
+      // Reset file input for re-uploading same file
+      if (fileInputRef.current) {
+        fileInputRef.current.value = "";
+      }
+    },
+    [tryParse],
+  );
+
+  const handleImport = useCallback(async () => {
+    if (!parsed) return;
+
+    setIsImporting(true);
+    setImportError(null);
+
+    try {
+      const result = await importSchema(apiSchemaId, serviceId, parsed);
+      if (!result.success) {
+        setImportError(result.error);
+        return;
+      }
+
+      setOpen(false);
+      setJsonText("");
+      setParsed(null);
+      onImported?.();
+    } catch {
+      setImportError("インポートに失敗しました");
+    } finally {
+      setIsImporting(false);
+    }
+  }, [parsed, apiSchemaId, serviceId, onImported]);
+
+  const handleOpenChange = useCallback(
+    (nextOpen: boolean) => {
+      setOpen(nextOpen);
+      if (!nextOpen) {
+        setJsonText("");
+        setParsed(null);
+        setParseError(null);
+        setImportError(null);
+      }
+    },
+    [],
+  );
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogTrigger asChild>
+        <Button variant="outline">
+          <Upload className="size-4" />
+          JSONからインポート
+        </Button>
+      </DialogTrigger>
+      <DialogContent className="max-w-2xl">
+        <DialogHeader>
+          <DialogTitle>スキーマインポート</DialogTitle>
+          <DialogDescription>
+            microCMS互換のJSON形式からスキーマフィールドをインポートします
+          </DialogDescription>
+        </DialogHeader>
+
+        <Tabs defaultValue="file" className="w-full">
+          <TabsList className="grid w-full grid-cols-2">
+            <TabsTrigger value="file">ファイルアップロード</TabsTrigger>
+            <TabsTrigger value="paste">テキスト貼り付け</TabsTrigger>
+          </TabsList>
+
+          <TabsContent value="file" className="space-y-4">
+            <div className="space-y-2">
+              <Label htmlFor="schema-file">JSONファイル</Label>
+              <input
+                ref={fileInputRef}
+                id="schema-file"
+                type="file"
+                accept=".json,application/json"
+                onChange={handleFileUpload}
+                className="block w-full text-sm file:mr-4 file:rounded-md file:border-0 file:bg-primary file:px-4 file:py-2 file:text-sm file:font-medium file:text-primary-foreground hover:file:bg-primary/90"
+              />
+            </div>
+          </TabsContent>
+
+          <TabsContent value="paste" className="space-y-4">
+            <div className="space-y-2">
+              <Label htmlFor="schema-json">JSON</Label>
+              <Textarea
+                id="schema-json"
+                placeholder='{"apiFields": [...], "customFields": [...]}'
+                rows={10}
+                value={jsonText}
+                onChange={(e) => tryParse(e.target.value)}
+                className="font-mono text-sm"
+              />
+            </div>
+          </TabsContent>
+        </Tabs>
+
+        {parseError && (
+          <p className="text-sm text-destructive">{parseError}</p>
+        )}
+
+        {importError && (
+          <p className="text-sm text-destructive">{importError}</p>
+        )}
+
+        {parsed && (
+          <div className="space-y-3 rounded-lg border p-4">
+            <p className="text-sm font-medium">プレビュー</p>
+            <div className="space-y-1">
+              <p className="text-muted-foreground text-xs">
+                APIフィールド ({parsed.apiFields.length})
+              </p>
+              <div className="flex flex-wrap gap-2">
+                {parsed.apiFields.map((f) => (
+                  <Badge key={f.fieldId} variant="secondary">
+                    {f.name} ({FIELD_TYPES[f.kind as FieldKind]?.label ?? f.kind})
+                  </Badge>
+                ))}
+              </div>
+            </div>
+            {parsed.customFields.length > 0 && (
+              <div className="space-y-1">
+                <p className="text-muted-foreground text-xs">
+                  カスタムフィールド ({parsed.customFields.length})
+                </p>
+                <div className="flex flex-wrap gap-2">
+                  {parsed.customFields.map((cf) => (
+                    <Badge key={cf.fieldId} variant="outline">
+                      {cf.name} ({cf.fields.length} サブフィールド)
+                    </Badge>
+                  ))}
+                </div>
+              </div>
+            )}
+          </div>
+        )}
+
+        <DialogFooter>
+          <Button
+            variant="outline"
+            onClick={() => handleOpenChange(false)}
+          >
+            キャンセル
+          </Button>
+          <Button
+            onClick={handleImport}
+            disabled={!parsed || isImporting}
+          >
+            {isImporting ? "インポート中..." : "インポート"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/features/content-hub/manage-schema/export-action.ts
+++ b/src/features/content-hub/manage-schema/export-action.ts
@@ -1,0 +1,142 @@
+"use server";
+
+import { requirePermission } from "@/shared/lib/auth-guard";
+import type { ActionResult } from "@/shared/types";
+
+import type { CustomField, SchemaField } from "../model";
+
+import { getSchemaFields } from "./query";
+import { getCustomFields } from "../manage-custom-fields/query";
+
+interface ExportedApiField {
+  fieldId: string;
+  name: string;
+  kind: string;
+  required: boolean;
+  description?: string | null;
+  [key: string]: unknown;
+}
+
+interface ExportedCustomFieldSubField {
+  idValue: string;
+  fieldId: string;
+  name: string;
+  kind: string;
+  required: boolean;
+  description?: string | null;
+  [key: string]: unknown;
+}
+
+interface ExportedCustomField {
+  createdAt: string;
+  fieldId: string;
+  name: string;
+  fields: ExportedCustomFieldSubField[];
+  position: string[][] | null;
+  updatedAt: string;
+}
+
+export interface SchemaExportData {
+  apiFields: ExportedApiField[];
+  customFields: ExportedCustomField[];
+}
+
+const VALIDATION_RULE_KEYS = [
+  "selectItems",
+  "multipleSelect",
+  "selectInitialValue",
+  "referencedApiEndpoint",
+  "unique",
+  "patternMatch",
+  "textSizeLimit",
+  "numberSizeLimit",
+  "customFieldCreatedAt",
+  "customFieldIds",
+  "minCount",
+  "maxCount",
+] as const;
+
+function flattenValidationRules(field: SchemaField): ExportedApiField {
+  const result: ExportedApiField = {
+    fieldId: field.fieldId,
+    name: field.name,
+    kind: field.kind,
+    required: field.required ?? false,
+  };
+
+  if (field.description) {
+    result.description = field.description;
+  }
+
+  if (field.validationRules && typeof field.validationRules === "object") {
+    const rules = field.validationRules as Record<string, unknown>;
+    for (const key of VALIDATION_RULE_KEYS) {
+      if (key in rules) {
+        result[key] = rules[key];
+      }
+    }
+  }
+
+  return result;
+}
+
+function exportCustomField(cf: CustomField): ExportedCustomField {
+  return {
+    createdAt: cf.createdAt.toISOString(),
+    fieldId: cf.fieldId,
+    name: cf.name,
+    fields: cf.fields.map((sub) => {
+      const exported: ExportedCustomFieldSubField = {
+        idValue: sub.idValue,
+        fieldId: sub.fieldId,
+        name: sub.name,
+        kind: sub.kind,
+        required: sub.required,
+      };
+      if (sub.description) {
+        exported.description = sub.description;
+      }
+      if (sub.validationRules && typeof sub.validationRules === "object") {
+        const rules = sub.validationRules as Record<string, unknown>;
+        for (const key of VALIDATION_RULE_KEYS) {
+          if (key in rules) {
+            exported[key] = rules[key];
+          }
+        }
+      }
+      return exported;
+    }),
+    position: cf.position,
+    updatedAt: cf.updatedAt.toISOString(),
+  };
+}
+
+export async function exportSchema(
+  apiSchemaId: string,
+  serviceId: string,
+): Promise<ActionResult<SchemaExportData>> {
+  try {
+    await requirePermission(serviceId, "schema.update");
+
+    const [schemaFields, customFieldList] = await Promise.all([
+      getSchemaFields(apiSchemaId),
+      getCustomFields(apiSchemaId),
+    ]);
+
+    const apiFields = schemaFields.map(flattenValidationRules);
+    const exportedCustomFields = customFieldList.map(exportCustomField);
+
+    return {
+      success: true,
+      data: {
+        apiFields,
+        customFields: exportedCustomFields,
+      },
+    };
+  } catch (error) {
+    if (error instanceof Error) {
+      return { success: false, error: error.message };
+    }
+    return { success: false, error: "スキーマのエクスポートに失敗しました" };
+  }
+}

--- a/src/features/content-hub/manage-schema/import-action.ts
+++ b/src/features/content-hub/manage-schema/import-action.ts
@@ -1,0 +1,148 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { db } from "@/db";
+import { customFields, schemaFields } from "@/db/schema";
+import type { ActionResult } from "@/shared/types";
+import { requirePermission } from "@/shared/lib/auth-guard";
+import { eq, sql } from "drizzle-orm";
+
+import { schemaImportSchema, type ImportApiField } from "./schema-import-validator";
+
+const VALIDATION_RULE_KEYS = [
+  "selectItems",
+  "multipleSelect",
+  "selectInitialValue",
+  "referencedApiEndpoint",
+  "unique",
+  "patternMatch",
+  "textSizeLimit",
+  "numberSizeLimit",
+  "customFieldCreatedAt",
+  "customFieldIds",
+  "minCount",
+  "maxCount",
+] as const;
+
+function extractValidationRules(field: ImportApiField): Record<string, unknown> | null {
+  const rules: Record<string, unknown> = {};
+  for (const key of VALIDATION_RULE_KEYS) {
+    if (key in field && field[key] !== undefined) {
+      rules[key] = field[key];
+    }
+  }
+  return Object.keys(rules).length > 0 ? rules : null;
+}
+
+export async function importSchema(
+  apiSchemaId: string,
+  serviceId: string,
+  jsonData: unknown,
+): Promise<ActionResult<{ fieldCount: number; customFieldCount: number }>> {
+  try {
+    await requirePermission(serviceId, "schema.create");
+
+    const parsed = schemaImportSchema.parse(jsonData);
+
+    const result = await db.transaction(async (tx) => {
+      // Create custom fields first so we can map createdAt references
+      const customFieldCreatedAtMap = new Map<string, string>();
+
+      for (const cf of parsed.customFields) {
+        const subFields = cf.fields.map((sub) => {
+          const subRules: Record<string, unknown> = {};
+          for (const key of VALIDATION_RULE_KEYS) {
+            const value = (sub as Record<string, unknown>)[key];
+            if (value !== undefined) {
+              subRules[key] = value;
+            }
+          }
+          return {
+            idValue: sub.idValue,
+            fieldId: sub.fieldId,
+            name: sub.name,
+            kind: sub.kind,
+            required: sub.required,
+            description: sub.description ?? null,
+            validationRules: Object.keys(subRules).length > 0 ? subRules : undefined,
+          };
+        });
+
+        const [created] = await tx
+          .insert(customFields)
+          .values({
+            apiSchemaId,
+            fieldId: cf.fieldId,
+            name: cf.name,
+            fields: subFields,
+            position: cf.position ?? null,
+          })
+          .returning();
+
+        // Map original createdAt to newly created custom field's createdAt
+        customFieldCreatedAtMap.set(
+          cf.createdAt,
+          created.createdAt.toISOString(),
+        );
+      }
+
+      // Get current max position
+      const [maxPos] = await tx
+        .select({
+          max: sql<number>`coalesce(max(${schemaFields.position}), -1)`,
+        })
+        .from(schemaFields)
+        .where(eq(schemaFields.apiSchemaId, apiSchemaId));
+
+      let position = (maxPos?.max ?? -1) + 1;
+
+      // Create schema fields
+      for (const field of parsed.apiFields) {
+        const rules = extractValidationRules(field);
+
+        // Map customFieldCreatedAt to the new custom field's createdAt
+        if (rules?.customFieldCreatedAt && typeof rules.customFieldCreatedAt === "string") {
+          const mapped = customFieldCreatedAtMap.get(rules.customFieldCreatedAt);
+          if (mapped) {
+            rules.customFieldCreatedAt = mapped;
+          }
+        }
+
+        // Map customFieldIds (for repeater fields) similarly
+        if (rules?.customFieldIds && Array.isArray(rules.customFieldIds)) {
+          rules.customFieldIds = (rules.customFieldIds as string[]).map((createdAt) => {
+            const mapped = customFieldCreatedAtMap.get(createdAt);
+            return mapped ?? createdAt;
+          });
+        }
+
+        await tx.insert(schemaFields).values({
+          apiSchemaId,
+          name: field.name,
+          fieldId: field.fieldId,
+          kind: field.kind,
+          description: field.description ?? null,
+          required: field.required ?? false,
+          position,
+          validationRules: rules,
+        });
+
+        position++;
+      }
+
+      return {
+        fieldCount: parsed.apiFields.length,
+        customFieldCount: parsed.customFields.length,
+      };
+    });
+
+    revalidatePath("/", "layout");
+
+    return { success: true, data: result };
+  } catch (error) {
+    if (error instanceof Error) {
+      return { success: false, error: error.message };
+    }
+    return { success: false, error: "スキーマのインポートに失敗しました" };
+  }
+}

--- a/src/features/content-hub/manage-schema/schema-import-validator.ts
+++ b/src/features/content-hub/manage-schema/schema-import-validator.ts
@@ -1,0 +1,52 @@
+import { z } from "zod";
+
+import { FIELD_KINDS } from "../field-types";
+
+const fieldKindEnum = z.enum(FIELD_KINDS as [string, ...string[]]);
+
+const importSubFieldSchema = z.object({
+  idValue: z.string().min(1),
+  fieldId: z.string().min(1).max(50),
+  name: z.string().min(1).max(100),
+  kind: fieldKindEnum,
+  required: z.boolean(),
+  description: z.string().nullable().optional(),
+}).passthrough();
+
+const importApiFieldSchema = z.object({
+  fieldId: z.string().min(1).max(50),
+  name: z.string().min(1).max(100),
+  kind: fieldKindEnum,
+  required: z.boolean().optional().default(false),
+  description: z.string().nullable().optional(),
+  selectItems: z.array(z.object({ id: z.string(), value: z.string() })).optional(),
+  multipleSelect: z.boolean().optional(),
+  selectInitialValue: z.array(z.string()).optional(),
+  referencedApiEndpoint: z.string().optional(),
+  unique: z.boolean().optional(),
+  patternMatch: z.string().optional(),
+  textSizeLimit: z.object({ min: z.number().optional(), max: z.number().optional() }).optional(),
+  numberSizeLimit: z.object({ min: z.number().optional(), max: z.number().optional() }).optional(),
+  customFieldCreatedAt: z.string().optional(),
+  customFieldIds: z.array(z.string()).optional(),
+  minCount: z.number().optional(),
+  maxCount: z.number().optional(),
+}).passthrough();
+
+const importCustomFieldSchema = z.object({
+  createdAt: z.string(),
+  fieldId: z.string().min(1).max(50),
+  name: z.string().min(1).max(100),
+  fields: z.array(importSubFieldSchema).min(1),
+  position: z.array(z.array(z.string())).nullable().optional(),
+  updatedAt: z.string(),
+});
+
+export const schemaImportSchema = z.object({
+  apiFields: z.array(importApiFieldSchema).min(1, "apiFieldsには1つ以上のフィールドが必要です"),
+  customFields: z.array(importCustomFieldSchema).optional().default([]),
+});
+
+export type SchemaImportInput = z.infer<typeof schemaImportSchema>;
+export type ImportApiField = z.infer<typeof importApiFieldSchema>;
+export type ImportCustomField = z.infer<typeof importCustomFieldSchema>;


### PR DESCRIPTION
## Summary
- **Content API serializer**: Updated to normalize field values based on schema field types (e.g., select values always returned as arrays). Handler now fetches schema fields and passes them to the serializer.
- **Schema export**: New server action + download button in schema builder that exports microCMS-compatible JSON with flattened validation rules, custom fields, and sub-field definitions.
- **Schema import**: New Zod-validated import action with transactional creation, plus dialog UI supporting file upload or JSON paste with field preview before importing.

## Test plan
- [ ] Verify content API responses correctly normalize select fields as arrays
- [ ] Export a schema with various field types (text, select, custom, repeater) and verify JSON format matches microCMS spec
- [ ] Import the exported JSON into a different API schema and verify all fields and custom fields are created correctly
- [ ] Test import with invalid JSON to verify validation error messages
- [ ] Test import with file upload and text paste modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)